### PR TITLE
Filter out games in a bad state (updated)

### DIFF
--- a/Salmonia.py
+++ b/Salmonia.py
@@ -173,7 +173,9 @@ class Salmonia():
             results = list(chunked(local, 10))
 
         for result in results:
-            data = list(map(lambda f: json.load(open(JsonPath(f), mode="r")), result))
+            data = list(filter(lambda fe: "message" not in fe, list(map(lambda f: json.load(open(JsonPath(f), mode="r")), result))))
+            if len(data) == 0:
+                continue
             response = requests.post(url, data=json.dumps({"results": data}), headers=header)
 
             # ログを表示


### PR DESCRIPTION
Ignore instances that are erroneous on SplatNet and consist of this:
{"message":"api_error_not_found_error","code":"NOT_FOUND_ERROR"}
instead of the normal data structure.

See #8 