### PR TITLE
Fix for the dropped game issue

### DIFF
--- a/Salmonia.py
+++ b/Salmonia.py
@@ -155,11 +155,18 @@ class Salmonia():
                     iksm_session=self.iksm_session)).text
                 with open(JsonPath(job_num), mode="w") as f:
                     f.write(response)
-            self.job_num["splatnet2"] = present
-            self.allResultToSalmonStats(range(preview + 1, present + 1))
         except Exception as error:
             self.update()
             self.getResultFromSplatNet2()
+            
+        try:
+            self.allResultToSalmonStats(range(preview + 1, present + 1))
+        except Exception as error:
+            sleep(5)
+            self.getResultFromSplatNet2()
+            
+        self.job_num["splatnet2"] = present
+
 
     # 起動時にJSONフォルダ内の未アップロードのリザルトを全てアップロード
 


### PR DESCRIPTION
split try in two, one relative to iksm session renewal, one related to salmon stats upload.
Reorder setting job_num to avoid dropping games. This is related to #14 

Here is an output example after the fix:

20:51:03 Result 21579 downloading
20:51:05 21579 -> 1421817 uploading
21:00:26 Result 21580 downloading
21:01:34 Result 21580 downloading
21:01:41 Result 21580 downloading
21:01:48 Result 21580 downloading
21:02:56 Result 21580 downloading
21:03:03 Result 21580 downloading
21:03:10 Result 21580 downloading
21:03:12 21580 -> 1421819 uploading
21:09:19 Result 21581 downloading
21:09:21 21581 -> 1421831 uploading

The game is downloaded too many times, but at least the upload is not missing