### PR TITLE
Error granularity fix in download/upload

### DIFF
--- a/Salmonia.py
+++ b/Salmonia.py
@@ -163,14 +163,14 @@ class Salmonia():
             self.update()
             return
                 
-        while True:
+        for i in range(5):
             try:
                 self.allResultToSalmonStats(range(preview + 1, present + 1))
                 break
             except Exception as error:
                 CLog(f"Upload error")
                 sleep(5)
-                # FIXME limit the number of retries?
+
         self.job_num["splatnet2"] = present
 
 

--- a/Salmonia.py
+++ b/Salmonia.py
@@ -142,12 +142,16 @@ class Salmonia():
     def getResultFromSplatNet2(self):
         try:
             present = self.getJobId()
-            preview = max(
-                self.job_num["splatnet2"], present - 49, int(self.job_num["salmonstats"]))
+        except Exception as error:
+            self.update()
+            return
 
-            if present == preview:
-                return
+        preview = max(self.job_num["splatnet2"], present - 49, int(self.job_num["salmonstats"]))
 
+        if present == preview:
+            return
+
+        try:
             for job_num in range(preview + 1, present + 1):
                 Log(f"Result {job_num} downloading")
                 url = f"https://app.splatoon2.nintendo.net/api/coop_results/{job_num}"
@@ -157,14 +161,16 @@ class Salmonia():
                     f.write(response)
         except Exception as error:
             self.update()
-            self.getResultFromSplatNet2()
-            
-        try:
-            self.allResultToSalmonStats(range(preview + 1, present + 1))
-        except Exception as error:
-            sleep(5)
-            self.getResultFromSplatNet2()
-            
+            return
+                
+        while True:
+            try:
+                self.allResultToSalmonStats(range(preview + 1, present + 1))
+                break
+            except Exception as error:
+                CLog(f"Upload error")
+                sleep(5)
+                # FIXME limit the number of retries?
         self.job_num["splatnet2"] = present
 
 

--- a/Salmonia.py
+++ b/Salmonia.py
@@ -162,15 +162,20 @@ class Salmonia():
         except Exception as error:
             self.update()
             return
-                
-        for i in range(5):
+         
+        upload_error = False
+        for i in range(5):            
             try:
                 self.allResultToSalmonStats(range(preview + 1, present + 1))
+                upload_error = False
                 break
             except Exception as error:
                 CLog(f"Upload error")
+                upload_error = True
                 sleep(5)
-
+        if upload_error:
+            return
+        
         self.job_num["splatnet2"] = present
 
 


### PR DESCRIPTION
Split the try to differentiate between splatnet-related errors (triggering an update()), and upload to Salmonia ones (triggering a loop/delay, capped at 5 right now, but could be infinite if you remove the last two commits).
Also, removed re-rentry on error to let the outer loop be in control.