### PR TITLE
Do not ask for results when SR is closed + stability fixes

### DIFF
--- a/iksm.py
+++ b/iksm.py
@@ -206,6 +206,7 @@ class UserInfo:
     result_id: int = 0
     host_type: int = 0
     name: str = "(undefined name)"
+    noupload: bool = False
     multi: bool = False
 
     @property
@@ -293,6 +294,7 @@ def renew_cookie(session: Session, userinfo: UserInfo, version: str, host_type: 
             host_type=host_type,
             name=splatoon_token.result.user.name,
             multi=userinfo.multi,
+            nouload=userinfo.noupload,
         )
     )
 

--- a/iksm.py
+++ b/iksm.py
@@ -3,6 +3,7 @@ from xml.dom import NotFoundErr
 from dataclasses_json import dataclass_json
 from typing import List, Type
 from typing import Optional
+from requests import Session
 import requests
 import re
 import urllib
@@ -220,7 +221,6 @@ class UserInfo:
         save(self)
 
 
-session = requests.Session()
 session_token_code_challenge = "tYLPO5PxpK-DTcAHJXugD7ztvAZQlo0DQQp3au5ztuM"
 session_token_code_verifier = "OwaTAOolhambwvY3RXSD-efxqdBEVNnQkc0bBJ7zaak"
 
@@ -230,23 +230,25 @@ class Type(Enum):
     APP = "app"
 
 
-def get_cookie(url_scheme, version: str, host_type: int = 0) -> UserInfo:
-    session_token = get_session_token(url_scheme, version)
-    print(session_token)
-    access_token = get_access_token(session_token.session_token, version)
-    print(access_token)
-    splatoon_token = get_splatoon_token(access_token, version)
-    print(splatoon_token)
-    splatoon_access_token = get_splatoon_access_token(splatoon_token, version)
-    print(splatoon_access_token)
-    iksm_session = get_iksm_session(splatoon_access_token, version)
-    print(iksm_session)
+def get_cookie(session: Session, url_scheme: str, version: str, host_type: int = 0) -> UserInfo:
+    RAWOut = open(1, 'w', encoding='utf8', closefd=False)
+    session_token = get_session_token(session, url_scheme, version)
+    print(f"Session token: {session_token}", file=RAWOut)
+    access_token = get_access_token(session, session_token.session_token, version)
+    print(f"Access token: {access_token}", file=RAWOut)
+    splatoon_token = get_splatoon_token(session, access_token, version)
+    print(f"Splatoon token: {splatoon_token}", file=RAWOut)
+    splatoon_access_token = get_splatoon_access_token(session, splatoon_token, version)
+    print(f"Splatoon Access Token: {splatoon_access_token}", file=RAWOut)
+    iksm_session = get_iksm_session(session, splatoon_access_token, version)
+    print(f"Iksm session: {iksm_session}", file=RAWOut)
     return save(
         UserInfo(
             session_token.session_token,
             iksm_session,
             splatoon_token.result.user.nsaId,
             splatoon_token.result.user.links.friendCode.id,
+            # should result_id for an initial run be 0?
             result_id=__get_latest_result_id(),
             host_type=host_type,
         )
@@ -269,29 +271,30 @@ def __get_latest_result_id() -> int:
         return 0
 
 
-def renew_cookie(session_token: str, version: str, host_type: int = 0, multi: bool = False) -> UserInfo:
-    access_token = get_access_token(session_token, version)
-    print(access_token)
-    splatoon_token = get_splatoon_token(access_token, version)
-    print(splatoon_token)
-    splatoon_access_token = get_splatoon_access_token(splatoon_token, version)
-    print(splatoon_access_token)
-    iksm_session = get_iksm_session(splatoon_access_token, version)
-    print(iksm_session)
+def renew_cookie(session: Session, userinfo: UserInfo, version: str, host_type: int = 0) -> UserInfo:
+    RAWOut = open(1, 'w', encoding='utf8', closefd=False)
+    access_token = get_access_token(session, userinfo.session_token, version)
+    print(f"Access token: {access_token}", file=RAWOut)
+    splatoon_token = get_splatoon_token(session, access_token, version)
+    print(f"Splatoon token: {splatoon_token}", file=RAWOut)
+    splatoon_access_token = get_splatoon_access_token(session, splatoon_token, version)
+    print(f"Splatoon Access Token: {splatoon_access_token}", file=RAWOut)
+    iksm_session = get_iksm_session(session, splatoon_access_token, version)
+    print(f"Iksm session: {iksm_session}", file=RAWOut)
     return save(
         UserInfo(
-            session_token,
+            userinfo.session_token,
             iksm_session,
             splatoon_token.result.user.nsaId,
             splatoon_token.result.user.links.friendCode.id,
-            result_id=__get_latest_result_id(),
+            result_id=userinfo.result_id,
             host_type=host_type,
-            multi=multi,
+            multi=userinfo.multi,
         )
     )
 
 
-def get_session_token_code(version: str):
+def get_session_token_code(session: Session, version: str):
     url = "https://accounts.nintendo.com/connect/1.0.0/authorize"
 
     parameters = {
@@ -311,7 +314,7 @@ def get_session_token_code(version: str):
     return response.history[0].url
 
 
-def get_session_token(url_scheme: str, version: str) -> SessionToken:
+def get_session_token(session: Session, url_scheme: str, version: str) -> SessionToken:
     session_token_code = re.search("de=(.*)&", url_scheme).group(1)
 
     url = "https://accounts.nintendo.com/connect/1.0.0/api/session_token"
@@ -337,7 +340,7 @@ def get_session_token(url_scheme: str, version: str) -> SessionToken:
         sys.exit(1)
 
 
-def get_access_token(session_token: str, version: str) -> AccessToken:
+def get_access_token(session: Session, session_token: str, version: str) -> AccessToken:
     url = "https://accounts.nintendo.com/connect/1.0.0/api/token"
     parameters = {
         "client_id": "71b963c1b7b6d119",
@@ -359,7 +362,7 @@ def get_access_token(session_token: str, version: str) -> AccessToken:
         sys.exit(1)
 
 
-def get_hash(access_token: str, timestamp: int, version: str) -> Hash:
+def get_hash(session: Session, access_token: str, timestamp: int, version: str) -> Hash:
     url = "https://s2s-hash-server.herokuapp.com/hash"
     parameters = {"naIdToken": access_token, "timestamp": timestamp}
     header = {
@@ -374,14 +377,14 @@ def get_hash(access_token: str, timestamp: int, version: str) -> Hash:
         sys.exit(1)
 
 
-def get_flapg(access_token: str, version: str, type: Type) -> Flapg:
+def get_flapg(session: Session, access_token: str, version: str, type: Type) -> Flapg:
     url = "https://flapg.com/ika2/api/login"
     timestamp = int(time.time())
     headers = {
         "x-token": access_token,
         "x-time": str(timestamp),
         "x-guid": "037239ef-1914-43dc-815d-178aae7d8934",
-        "x-hash": get_hash(access_token, timestamp, version).hash,
+        "x-hash": get_hash(session, access_token, timestamp, version).hash,
         "x-ver": "3",
         "x-iid": type.value,
     }
@@ -394,9 +397,9 @@ def get_flapg(access_token: str, version: str, type: Type) -> Flapg:
         sys.exit(1)
 
 
-def get_splatoon_token(access_token: AccessToken, version: str):
+def get_splatoon_token(session: Session, access_token: AccessToken, version: str):
     url = "https://api-lp1.znc.srv.nintendo.net/v3/Account/Login"
-    result = get_flapg(access_token.access_token, version, Type.NSO).result
+    result = get_flapg(session, access_token.access_token, version, Type.NSO).result
     parameters = {
         "parameter": {
             "f": result.f,
@@ -423,10 +426,10 @@ def get_splatoon_token(access_token: AccessToken, version: str):
         print(f"TypeError: {response.error}")
 
 
-def get_splatoon_access_token(splatoon_token: SplatoonToken, version: str):
+def get_splatoon_access_token(session: Session, splatoon_token: SplatoonToken, version: str):
     url = "https://api-lp1.znc.srv.nintendo.net/v2/Game/GetWebServiceToken"
     access_token = splatoon_token.result.webApiServerCredential.accessToken
-    result = get_flapg(access_token, version, Type.APP).result
+    result = get_flapg(session, access_token, version, Type.APP).result
     parameters = {
         "parameter": {
             "id": 5741031244955648,
@@ -452,7 +455,7 @@ def get_splatoon_access_token(splatoon_token: SplatoonToken, version: str):
         print(f"TypeError: {response.errorMessage}")
 
 
-def get_iksm_session(splatoon_access_token: SplatoonAccessToken, version: str):
+def get_iksm_session(session: Session, splatoon_access_token: SplatoonAccessToken, version: str):
     url = "https://app.splatoon2.nintendo.net"
     headers = {
         "Cookie": "iksm_session=",
@@ -466,7 +469,7 @@ def get_iksm_session(splatoon_access_token: SplatoonAccessToken, version: str):
         print(f"TypeError: invalid splatoon access token")
 
 
-def get_app_version() -> str:
+def get_app_version(session: Session) -> str:
     url = "https://itunes.apple.com/lookup?id=1234806557"
     try:
         response = session.get(url)
@@ -475,12 +478,12 @@ def get_app_version() -> str:
         print(f"TypeError: invalid id")
 
 
-def request(url: str, iksm_session: str) -> str:
+def request(session: Session, url: str, iksm_session: str) -> str:
     cookies = dict(iksm_session=iksm_session)
     return session.get(url, cookies=cookies).text
 
 
-def post(url: str, json: json):
+def post(session: Session, url: str, json: json):
     session.post(url, json=json)
 
 

--- a/iksm.py
+++ b/iksm.py
@@ -205,6 +205,7 @@ class UserInfo:
     friend_code: str
     result_id: int = 0
     host_type: int = 0
+    name: str = "(undefined name)"
     multi: bool = False
 
     @property
@@ -251,6 +252,7 @@ def get_cookie(session: Session, url_scheme: str, version: str, host_type: int =
             # should result_id for an initial run be 0?
             result_id=__get_latest_result_id(),
             host_type=host_type,
+            name=splatoon_token.result.user.name,
         )
     )
 
@@ -289,6 +291,7 @@ def renew_cookie(session: Session, userinfo: UserInfo, version: str, host_type: 
             splatoon_token.result.user.links.friendCode.id,
             result_id=userinfo.result_id,
             host_type=host_type,
+            name=splatoon_token.result.user.name,
             multi=userinfo.multi,
         )
     )

--- a/main.py
+++ b/main.py
@@ -13,9 +13,11 @@ def main(args):
     if args.multi:
         with open("multi.json", 'r', encoding="utf-8") as f:
             players = json.load(f)
+            interval_offset = 0
             for player in players['list']:
                 s = Salmonia(player)
-                schedule.every(10).seconds.do(s.upload_all_result)
+                schedule.every(10+interval_offset).seconds.do(s.upload_all_result)
+                interval_offset += 1
     else:
         session = Salmonia()
         schedule.every(10).seconds.do(session.upload_all_result)

--- a/salmonia.py
+++ b/salmonia.py
@@ -275,8 +275,8 @@ class Salmonia:
             self.upload_local_result()
 
         curtime = time.time()
-        # Check if Salmon Run is open
-        if (self.rotation['end'] == 0) or (curtime > self.rotation['end']):
+        # Check if Salmon Run is open (we allow 10mn for an extra run)
+        if (self.rotation['end'] == 0) or (curtime > (self.rotation['end'] + 600)):
             self.rotation = self.__get_rotation()
         if self.initializing:
             self.initializing = False

--- a/salmonia.py
+++ b/salmonia.py
@@ -250,7 +250,13 @@ class Salmonia:
         # if will be attempted next run
         if self.upload_error:
             return
-
+        if self.userinfo.noupload:
+            print(
+                    f"\r{datetime.now().strftime('%m-%d %H:%M:%S')} Local Process {self.userinfo.nsa_id}/{result_id}",
+                    end="",
+                )
+            self.userinfo.job_num = max(result_id, self.userinfo.job_num)
+            return
         # Upload a result
         url = f"{self.host_type.url()}/results"
         parameters = {"results": [result]}

--- a/salmonia.py
+++ b/salmonia.py
@@ -171,8 +171,8 @@ class Salmonia:
             response = Results.from_json(self.__request_with_auth(url).text)
             return response.summary.card.job_num
         except Exception as e:
-            print(f"Uncaught exception : {e}")
-            sys.exit(1)
+            # return the last processed id -> no new game, stay silent
+            return self.userinfo.result_id
 
     def get_local_latest_result_id(self) -> int:
         fullpath = "results"


### PR DESCRIPTION
Unless it is a first run, do not request results when SR is closed. An extra 10mn is allowed at the end of the rotation.
* Check SR rotation schedule
* Allow download-only mode when uploading doesn't work
* Change the pending upload to be used after an upload error
* Be careful with session and cookie jars 
* Add name in configuration, useful to track accounts
* Add a noupload mode for when someone don't want to upload some games